### PR TITLE
version bump to 0.1.5

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "roc-chart",
-  "version": "0.1.4",
+  "version": "0.1.5",
   "description": "a chart that plots receiver operating characteristic curves",
   "main": "build/roc-chart.js",
   "scripts": {


### PR DESCRIPTION
I re-published the package to the Nexus server, because I thought that would fix a problem I was seeing in the package (the compiled version did not match the source code).

Unfortunately, it did not solve the problem, but we need to merge this, so that the version matches what is currently published on the Nexus server.
