### PR TITLE
Fixes issues related to properly transpiling to es5

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,0 +1,3 @@
+{
+  "presets": ["es2015-rollup"]
+}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "roc-chart",
-  "version": "0.2.10",
+  "version": "0.2.12",
   "description": "a chart that plots receiver operating characteristic curves",
   "main": "build/bundle.js",
   "scripts": {
@@ -12,7 +12,7 @@
     "type": "git",
     "url": "git+https://github.com/h2oai/vis-components.git"
   },
-  "homepage": "https://github.com/h2oai/vis-components",
+  "homepage": "https://github.com/h2oai/vis-components#readme",
   "publishConfig": {
     "registry": "http://172.17.0.53:8081/nexus/content/repositories/npm-internal/"
   },
@@ -42,7 +42,6 @@
   "bugs": {
     "url": "https://github.com/h2oai/vis-components/issues"
   },
-  "homepage": "https://github.com/h2oai/vis-components#readme",
   "devDependencies": {
     "babel-preset-es2015-rollup": "^1.1.1",
     "eslint": "^2.13.1",
@@ -52,7 +51,8 @@
     "eslint-plugin-react": "^5.2.2",
     "package-preamble": "0.0",
     "rollup": "0.33",
-    "rollup-plugin-babel": "^2.6.1"
+    "rollup-plugin-babel": "^2.6.1",
+    "rollup-plugin-json": "^2.0.1"
   },
   "dependencies": {
     "d3": "^3.5.17"


### PR DESCRIPTION
This PR ensures that the contents of `index.js` are also transpiled from `es2015` to `es5` by adding a `.babelrc` file in the root directory
